### PR TITLE
ltcd: rpctest to work in conjunction with btcd rpctest 

### DIFF
--- a/integration/rpctest/btcd.go
+++ b/integration/rpctest/btcd.go
@@ -44,16 +44,16 @@ func btcdExecutablePath() (string, error) {
 	}
 
 	// Build btcd and output an executable in a static temp path.
-	outputPath := filepath.Join(testDir, "btcd")
+	outputPath := filepath.Join(testDir, "ltcd")
 	if runtime.GOOS == "windows" {
 		outputPath += ".exe"
 	}
 	cmd := exec.Command(
-		"go", "build", "-o", outputPath, "github.com/btcsuite/btcd",
+		"go", "build", "-o", outputPath, "github.com/ltcsuite/ltcd",
 	)
 	err = cmd.Run()
 	if err != nil {
-		return "", fmt.Errorf("Failed to build btcd: %v", err)
+		return "", fmt.Errorf("Failed to build ltcd: %v", err)
 	}
 
 	// Save executable path so future calls do not recompile.

--- a/integration/rpctest/rpc_harness.go
+++ b/integration/rpctest/rpc_harness.go
@@ -482,7 +482,7 @@ func generateListeningAddresses() (string, string) {
 	localhost := "127.0.0.1"
 
 	portString := func(minPort, maxPort int) string {
-		port := minPort + numTestInstances + ((20 * processID) %
+		port := maxPort - numTestInstances - ((20 * processID) %
 			(maxPort - minPort))
 		return strconv.Itoa(port)
 	}

--- a/integration/rpctest/rpc_harness.go
+++ b/integration/rpctest/rpc_harness.go
@@ -494,7 +494,7 @@ func generateListeningAddresses() (string, string) {
 
 // baseDir is the directory path of the temp directory for all rpctest files.
 func baseDir() (string, error) {
-	dirPath := filepath.Join(os.TempDir(), "btcd", "rpctest")
+	dirPath := filepath.Join(os.TempDir(), "ltcd", "rpctest")
 	err := os.MkdirAll(dirPath, 0755)
 	return dirPath, err
 }


### PR DESCRIPTION

* `rpctest` to target `ltcd` build instead of `btcd` build.
* `rpctest` to use different port sequence then what's used in `btcd`'s `rpctest`. This is necessary for `rpctest` of `ltcd` & `btcd` to work in conjunction.

