### PR TITLE
Fix chain parameters of regtest

### DIFF
--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -380,11 +380,11 @@ var RegressionNetParams = Params{
 
 	// Human-readable part for Bech32 encoded segwit addresses, as defined in
 	// BIP 173.
-	Bech32HRPSegwit: "bcrt", // always bcrt for reg test net
+	Bech32HRPSegwit: "rltc", // always rltc for reg test net
 
 	// Address encoding magics
 	PubKeyHashAddrID: 0x6f, // starts with m or n
-	ScriptHashAddrID: 0xc4, // starts with 2
+	ScriptHashAddrID: 0x3a, // starts with Q
 	PrivateKeyID:     0xef, // starts with 9 (uncompressed) or c (compressed)
 
 	// BIP32 hierarchical deterministic extended key magics


### PR DESCRIPTION
While working with LND on the Litecoin regtest network I noticed that the generated addresses don't have the prefixes that I expected.

I had a look at the code of LND to find the reason for this and found out that the Litecoin address encoding magics are provided by LTCD. Therefore I opened this PR.